### PR TITLE
Feature/add 2024 isbi goat algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,19 +377,29 @@ segmenter.infer_single(
 > Note: The SRI24 atlas, available on [Zenodo](https://zenodo.org/records/15927391), was employed for registration in BraTS Pediatric Tumor Segmentation challenges.
 <br>
 
-#### Generalizability Across Tumors (BraTS-GoAT) Segmentation 
-> Segmentation algorithm, adapting and generalizing to different brain tumors with segmentation labels of different tumor sub-regions. 
+## Generalizability Across Tumors (BraTS-GoAT) Segmentation
+
+Segmentation algorithms for generalization across brain tumors with multiple tumor sub-region labels.  
+This section includes **MICCAI BraTS-GoAT** and **ISBI BraTS-GoAT (2024)** submissions as separate algorithm families.
+
+---
 
 <details>
-<summary> Usage example (code) and top 3 participants </summary>
+<summary>Usage example (code)</summary>
 <br>
+
+### MICCAI BraTS-GoAT example
 
 ```python
 from brats import GoATSegmenter
 from brats.constants import GoATAlgorithms
 
-segmenter = GoATSegmenter(algorithm=GoATAlgorithms.BraTS25_1A, cuda_devices="0")
-# these parameters are optional, by default the latest winning algorithm will be used on cuda:0
+segmenter = GoATSegmenter(
+    algorithm=GoATAlgorithms.BraTS25_1A,
+    cuda_devices="0"
+)
+
+# Optional: defaults to latest MICCAI GoAT model on cuda:0
 segmenter.infer_single(
     t1c="path/to/t1c.nii.gz",
     t1n="path/to/t1n.nii.gz",
@@ -398,8 +408,20 @@ segmenter.infer_single(
     output_file="segmentation.nii.gz",
 )
 ```
+### IEEE-ISBI BraTS-GoAT example
 
-**Class:** `brats.PediatricSegmenter` ([Docs](https://brats.readthedocs.io/en/latest/core/segmentation_algorithms.html#brats.core.segmentation_algorithms.PediatricSegmenter))
+```python
+from brats import ISBIGoATSegmenter
+from brats.constants import ISBIGoATAlgorithms
+
+segmenter = GoATSegmenter(
+    algorithm=ISBIGoATAlgorithms.BraTS24_ISBI_1,
+    cuda_devices="0"
+)
+```
+
+**Class:** `brats.GoATSegmenter` ([Docs](https://brats.readthedocs.io/en/latest/core/segmentation_algorithms.html#brats.core.segmentation_algorithms.GoATSegmenter))
+**Class:** `brats.ISBIGoATSegmenter` ([Docs](https://brats.readthedocs.io/en/latest/core/segmentation_algorithms.html#brats.core.segmentation_algorithms.ISBIGoATSegmenter))
 <br>
 **Challenge Paper 2024:** N/A
 <br> 
@@ -418,9 +440,9 @@ segmenter.infer_single(
 
 | Year | Rank | Author                    | Paper         | CPU Support     | Key Enum                                                                                                                    |
 | ---- | ---- | ------------------------- | ------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| 2024 | 1st  | *[AUTHOR_NAME_1, et al.]* | [PAPER_URL_1] | [CPU_SUPPORT_1] | [BraTS24_ISBI_1](https://brats.readthedocs.io/en/latest/utils/utils.html#brats.constants.ISBIGoATAlgorithms.BraTS24_ISBI_1) |
-| 2024 | 2nd  | *[AUTHOR_NAME_2, et al.]* | [PAPER_URL_2] | [CPU_SUPPORT_2] | [BraTS24_ISBI_2](https://brats.readthedocs.io/en/latest/utils/utils.html#brats.constants.ISBIGoATAlgorithms.BraTS24_ISBI_2) |
-| 2024 | 3rd  | *[AUTHOR_NAME_3, et al.]* | [PAPER_URL_3] | [CPU_SUPPORT_3] | [BraTS24_ISBI_3](https://brats.readthedocs.io/en/latest/utils/utils.html#brats.constants.ISBIGoATAlgorithms.BraTS24_ISBI_3) |
+| 2024 | 1st  | _André Ferreira, et al._ | [PAPER_URL_1] |[CPU_SUPPORT_1] | [BraTS24_ISBI_1](https://brats.readthedocs.io/en/latest/utils/utils.html#brats.constants.ISBIGoATAlgorithms.BraTS24_ISBI_1) |
+| 2024 | 2nd  | _Anees Hashimi, et al._ | [PAPER_URL_2] | [CPU_SUPPORT_2] | [BraTS24_ISBI_2](https://brats.readthedocs.io/en/latest/utils/utils.html#brats.constants.ISBIGoATAlgorithms.BraTS24_ISBI_2) |
+
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -414,14 +414,14 @@ segmenter.infer_single(
 from brats import ISBIGoATSegmenter
 from brats.constants import ISBIGoATAlgorithms
 
-segmenter = GoATSegmenter(
+segmenter = ISBIGoATSegmenter(
     algorithm=ISBIGoATAlgorithms.BraTS24_ISBI_1,
     cuda_devices="0"
 )
 ```
 
-**Class:** `brats.GoATSegmenter` ([Docs](https://brats.readthedocs.io/en/latest/core/segmentation_algorithms.html#brats.core.segmentation_algorithms.GoATSegmenter))
-**Class:** `brats.ISBIGoATSegmenter` ([Docs](https://brats.readthedocs.io/en/latest/core/segmentation_algorithms.html#brats.core.segmentation_algorithms.ISBIGoATSegmenter))
+**MICCAI Class:** `brats.GoATSegmenter` ([Docs](https://brats.readthedocs.io/en/latest/core/segmentation_algorithms.html#brats.core.segmentation_algorithms.GoATSegmenter))
+**ISBI Class:** `brats.ISBIGoATSegmenter` ([Docs](https://brats.readthedocs.io/en/latest/core/segmentation_algorithms.html#brats.core.segmentation_algorithms.ISBIGoATSegmenter))
 <br>
 **Challenge Paper 2024:** N/A
 <br> 

--- a/README.md
+++ b/README.md
@@ -440,8 +440,8 @@ segmenter = ISBIGoATSegmenter(
 
 | Year | Rank | Author                    | Paper         | CPU Support     | Key Enum                                                                                                                    |
 | ---- | ---- | ------------------------- | ------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| 2024 | 1st  | _André Ferreira, et al._ | [PAPER_URL_1] |[CPU_SUPPORT_1] | [BraTS24_ISBI_1](https://brats.readthedocs.io/en/latest/utils/utils.html#brats.constants.ISBIGoATAlgorithms.BraTS24_ISBI_1) |
-| 2024 | 2nd  | _Anees Hashimi, et al._ | [PAPER_URL_2] | [CPU_SUPPORT_2] | [BraTS24_ISBI_2](https://brats.readthedocs.io/en/latest/utils/utils.html#brats.constants.ISBIGoATAlgorithms.BraTS24_ISBI_2) |
+| 2024 | 1st  | _André Ferreira, et al._ | https://arxiv.org/abs/2402.17317 | &#x274C; | [BraTS24_ISBI_1](https://brats.readthedocs.io/en/latest/utils/utils.html#brats.constants.ISBIGoATAlgorithms.BraTS24_ISBI_1) |
+| 2024 | 2nd  | _Anees Hashmi, et al._ | [PAPER_URL_2] | [CPU_SUPPORT_2] | [BraTS24_ISBI_2](https://brats.readthedocs.io/en/latest/utils/utils.html#brats.constants.ISBIGoATAlgorithms.BraTS24_ISBI_2) |
 
 
 </details>

--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ segmenter.infer_single(
 
 #### Generalizability Across Tumors (BraTS-GoAT) Segmentation 
 > Segmentation algorithm, adapting and generalizing to different brain tumors with segmentation labels of different tumor sub-regions. 
+
 <details>
 <summary> Usage example (code) and top 3 participants </summary>
 <br>
@@ -403,6 +404,8 @@ segmenter.infer_single(
 **Challenge Paper 2024:** N/A
 <br> 
 
+##### MICCAI BraTS-GoAT Algorithms (`GoATAlgorithms`)
+
 | Year | Rank | Author                      | Paper | CPU Support | Key Enum                                                                                                        |
 | ---- | ---- | --------------------------- | ----- | ----------- | --------------------------------------------------------------------------------------------------------------- |
 | 2025 | 1st  | _Meng-Yuan Chen, et al._    | N/A   | &#x274C;    | [BraTS25_1A](https://brats.readthedocs.io/en/latest/utils/utils.html#brats.constants.GoATAlgorithms.BraTS25_1A) |
@@ -410,6 +413,16 @@ segmenter.infer_single(
 | 2025 | 1st  | _Vaidehi Satushe, et al._   | N/A   | &#x274C;    | [BraTS25_1C](https://brats.readthedocs.io/en/latest/utils/utils.html#brats.constants.GoATAlgorithms.BraTS25_1C) |
 | 2025 | 1st  | _Simone Bendazzoli, et al._ | N/A   | &#x274C;    | [BraTS25_1D](https://brats.readthedocs.io/en/latest/utils/utils.html#brats.constants.GoATAlgorithms.BraTS25_1D) |
 | 2024 | 1st  | _Frank Miao, Shengjie Niu_  | N/A   | &#x274C;    | [BraTS24_1](https://brats.readthedocs.io/en/latest/utils/utils.html#brats.constants.GoATAlgorithms.BraTS24_1)   |
+
+##### ISBI BraTS-GoAT Algorithms (`ISBIGoATAlgorithms`)
+
+| Year | Rank | Author                    | Paper         | CPU Support     | Key Enum                                                                                                                    |
+| ---- | ---- | ------------------------- | ------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| 2024 | 1st  | *[AUTHOR_NAME_1, et al.]* | [PAPER_URL_1] | [CPU_SUPPORT_1] | [BraTS24_ISBI_1](https://brats.readthedocs.io/en/latest/utils/utils.html#brats.constants.ISBIGoATAlgorithms.BraTS24_ISBI_1) |
+| 2024 | 2nd  | *[AUTHOR_NAME_2, et al.]* | [PAPER_URL_2] | [CPU_SUPPORT_2] | [BraTS24_ISBI_2](https://brats.readthedocs.io/en/latest/utils/utils.html#brats.constants.ISBIGoATAlgorithms.BraTS24_ISBI_2) |
+| 2024 | 3rd  | *[AUTHOR_NAME_3, et al.]* | [PAPER_URL_3] | [CPU_SUPPORT_3] | [BraTS24_ISBI_3](https://brats.readthedocs.io/en/latest/utils/utils.html#brats.constants.ISBIGoATAlgorithms.BraTS24_ISBI_3) |
+
+</details>
 
 </details>
 

--- a/brats/__init__.py
+++ b/brats/__init__.py
@@ -7,7 +7,7 @@ from brats.core.segmentation_algorithms import (
     AdultGliomaPreAndPostTreatmentSegmenter,
     AfricaSegmenter,
     GoATSegmenter,
-    ISBIGoATSegmenter,  
+    ISBIGoATSegmenter,
     MeningiomaSegmenter,
     MetastasesSegmenter,
     MeningiomaRTSegmenter,

--- a/brats/__init__.py
+++ b/brats/__init__.py
@@ -7,6 +7,7 @@ from brats.core.segmentation_algorithms import (
     AdultGliomaPreAndPostTreatmentSegmenter,
     AfricaSegmenter,
     GoATSegmenter,
+    ISBIGoATSegmenter,  
     MeningiomaSegmenter,
     MetastasesSegmenter,
     MeningiomaRTSegmenter,

--- a/brats/constants.py
+++ b/brats/constants.py
@@ -216,7 +216,9 @@ class MissingMRIAlgorithms(Algorithms):
 
 
 class GoATAlgorithms(Algorithms):
-    """Constants for the available missing mri  algorithms."""
+    """Constants for the available missing mri  algorithms.
+    BraTS GoAT algorithms from MICCAI conference.
+    """
 
     BraTS25_1A = "BraTS25_1A"
     """ BraTS25 Generalizability Across Tumors (BraTS-GoAT) 1st place (tie) """
@@ -230,6 +232,20 @@ class GoATAlgorithms(Algorithms):
     BraTS24_1 = "BraTS24_1"
     """ BraTS24 Generalizability Across Tumors (BraTS-GoAT) 1st place (The only submission)"""
 
+
+class ISBIGoATAlgorithms(Algorithms):
+    """Constants for the available ISBI BraTS GoAT algorithms.
+    
+    These algorithms are from the ISBI 2024 conference, separate from
+    the MICCAI BraTS GoAT algorithms in GoATAlgorithms.
+    """
+
+    BraTS24_ISBI_1 = "BraTS24_ISBI_1"
+    """ BraTS24 ISBI - Generalizability Across Tumors 1st place """
+    BraTS24_ISBI_2 = "BraTS24_ISBI_2"
+    """ BraTS24 ISBI - Generalizability Across Tumors 2nd place """
+    BraTS24_ISBI_3 = "BraTS24_ISBI_3"
+    """ BraTS24 ISBI - Generalizability Across Tumors 3rd place """
 
 # DIRECTORIES
 DATA_DIR = Path(__file__).parent / "data"

--- a/brats/constants.py
+++ b/brats/constants.py
@@ -235,7 +235,7 @@ class GoATAlgorithms(Algorithms):
 
 class ISBIGoATAlgorithms(Algorithms):
     """Constants for the available ISBI BraTS GoAT algorithms.
-    
+
     These algorithms are from the ISBI 2024 conference, separate from
     the MICCAI BraTS GoAT algorithms in GoATAlgorithms.
     """
@@ -244,7 +244,7 @@ class ISBIGoATAlgorithms(Algorithms):
     """ BraTS24 ISBI - Generalizability Across Tumors 1st place """
     BraTS24_ISBI_2 = "BraTS24_ISBI_2"
     """ BraTS24 ISBI - Generalizability Across Tumors 2nd place """
- 
+
 
 # DIRECTORIES
 DATA_DIR = Path(__file__).parent / "data"

--- a/brats/constants.py
+++ b/brats/constants.py
@@ -244,8 +244,7 @@ class ISBIGoATAlgorithms(Algorithms):
     """ BraTS24 ISBI - Generalizability Across Tumors 1st place """
     BraTS24_ISBI_2 = "BraTS24_ISBI_2"
     """ BraTS24 ISBI - Generalizability Across Tumors 2nd place """
-    BraTS24_ISBI_3 = "BraTS24_ISBI_3"
-    """ BraTS24 ISBI - Generalizability Across Tumors 3rd place """
+ 
 
 # DIRECTORIES
 DATA_DIR = Path(__file__).parent / "data"

--- a/brats/core/segmentation_algorithms.py
+++ b/brats/core/segmentation_algorithms.py
@@ -21,6 +21,7 @@ from brats.constants import (
     AfricaAlgorithms,
     Algorithms,
     GoATAlgorithms,
+    ISBIGoATAlgorithms,
     MeningiomaAlgorithms,
     MeningiomaRTAlgorithms,
     MetastasesAlgorithms,
@@ -382,6 +383,30 @@ class GoATSegmenter(SegmentationAlgorithmWith4Modalities):
             force_cpu=force_cpu,
         )
 
+class ISBIGoATSegmenter(SegmentationAlgorithmWith4Modalities):
+    """Provides algorithms from the ISBI 2024 BraTS Generalizability Across Tumors (BraTS-GoAT) challenge.
+    
+    Note: This class contains algorithms from the ISBI 2024 conference.
+    For MICCAI 2024 algorithms, use GoATSegmenter instead.
+
+    Args:
+        algorithm (ISBIGoATAlgorithms, optional): Select an algorithm. Defaults to ISBIGoATAlgorithms.BraTS24_ISBI_1.
+        cuda_devices (Optional[str], optional): Which cuda devices to use. Defaults to "0".
+        force_cpu (bool, optional): Execution will default to GPU, this flag allows forced CPU execution if the algorithm is compatible. Defaults to False.
+    """
+
+    def __init__(
+        self,
+        algorithm: ISBIGoATAlgorithms = ISBIGoATAlgorithms.BraTS24_ISBI_1,
+        cuda_devices: str = "0",
+        force_cpu: bool = False,
+    ):
+        super().__init__(
+            algorithm=algorithm,
+            algorithms_file_path=GOAT_SEGMENTATION_ALGORITHMS,
+            cuda_devices=cuda_devices,
+            force_cpu=force_cpu,
+        )
 
 ### Radio Therapy specific segmenter (only T1C) ###
 

--- a/brats/core/segmentation_algorithms.py
+++ b/brats/core/segmentation_algorithms.py
@@ -383,9 +383,10 @@ class GoATSegmenter(SegmentationAlgorithmWith4Modalities):
             force_cpu=force_cpu,
         )
 
+
 class ISBIGoATSegmenter(SegmentationAlgorithmWith4Modalities):
     """Provides algorithms from the ISBI 2024 BraTS Generalizability Across Tumors (BraTS-GoAT) challenge.
-    
+
     Note: This class contains algorithms from the ISBI 2024 conference.
     For MICCAI 2024 algorithms, use GoATSegmenter instead.
 
@@ -407,6 +408,7 @@ class ISBIGoATSegmenter(SegmentationAlgorithmWith4Modalities):
             cuda_devices=cuda_devices,
             force_cpu=force_cpu,
         )
+
 
 ### Radio Therapy specific segmenter (only T1C) ###
 

--- a/brats/core/segmentation_algorithms.py
+++ b/brats/core/segmentation_algorithms.py
@@ -365,7 +365,7 @@ class GoATSegmenter(SegmentationAlgorithmWith4Modalities):
     """Provides algorithms from the BraTS Generalizability Across Tumors (BraTS-GoAT)
 
     Args:
-        algorithm (GoATAlgorithms, optional): Select an algorithm. Defaults to GoATAlgorithms.BraTS23_1.
+        algorithm (GoATAlgorithms, optional): Select an algorithm. Defaults to GoATAlgorithms.BraTS25_1.
         cuda_devices (Optional[str], optional): Which cuda devices to use. Defaults to "0".
         force_cpu (bool, optional): Execution will default to GPU, this flag allows forced CPU execution if the algorithm is compatible. Defaults to False.
     """

--- a/brats/data/meta/goat.yml
+++ b/brats/data/meta/goat.yml
@@ -82,3 +82,51 @@ algorithms:
       input_name_schema: *input_name_schema
       requires_root: false
       parameters_file: false
+
+
+# Additional algorithms from the ISBI GoAT challeng 2024 (not Miccai), only placholders so far
+
+  BraTS24_ISBI_1:
+    meta:
+      authors: "[AUTHOR_NAME_1, et al.]"
+      paper: "[PAPER_URL_1]"
+      challenge: *challenge
+      challenge_manuscript: *challenge_manuscript_2024
+      rank: *rank_1
+      year: *year_2024
+    run_args:
+      docker_image: brainles/brats24_isbi_algorithm1:latest
+      input_name_schema: *input_name_schema
+      requires_root: "[ROOT_REQUIREMENT_1]"
+      parameters_file: false
+
+
+  BraTS24_ISBI_2:
+    meta:
+      authors: "[AUTHOR_NAME_2, et al.]"
+      paper: "[PAPER_URL_2]"
+      challenge: *challenge
+      challenge_manuscript: *challenge_manuscript_2024
+      rank: *rank_2
+      year: *year_2024
+    run_args:
+      docker_image: brainles/brats24_isbi_algorithm2:latest
+      input_name_schema: *input_name_schema
+      requires_root: "[ROOT_REQUIREMENT_2]"
+      parameters_file: false
+
+
+
+  BraTS24_ISBI_3:
+    meta:
+      authors: "[AUTHOR_NAME_3, et al.]"
+      paper: "[PAPER_URL_3]"
+      challenge: *challenge
+      challenge_manuscript: *challenge_manuscript_2024
+      rank: *rank_3
+      year: *year_2024
+    run_args:
+      docker_image: brainles/brats24_isbi_algorithm3:latest
+      input_name_schema: *input_name_schema
+      requires_root: "[ROOT_REQUIREMENT_3]"
+      parameters_file: false      

--- a/brats/data/meta/goat.yml
+++ b/brats/data/meta/goat.yml
@@ -1,9 +1,15 @@
 constants:
   input_name_schema: &input_name_schema "BraTS-GLI-{id:05d}-000"
   challenge: &challenge "BraTS Generalizability Across Tumors (BraTS-GoAT)"
+  isbi_challenge: &isbi_challenge "IEEE-ISBI BraTS GoAT Challenge 2024"
+
   challenge_manuscript:
     2025: &challenge_manuscript_2025 "N/A"
     2024: &challenge_manuscript_2024 "N/A"
+
+  isbi_challenge_manuscript:
+    2024: &isbi_challenge_manuscript_2024 "N/A"
+
   years:
     2025: &year_2025 2025
     2024: &year_2024 2024
@@ -88,45 +94,30 @@ algorithms:
 
   BraTS24_ISBI_1:
     meta:
-      authors: "[AUTHOR_NAME_1, et al.]"
+      authors: "[André Ferreira, et al.]"
       paper: "[PAPER_URL_1]"
-      challenge: *challenge
-      challenge_manuscript: *challenge_manuscript_2024
+      challenge: *isbi_challenge
+      challenge_manuscript: *isbi_challenge_manuscript_2024
       rank: *rank_1
       year: *year_2024
     run_args:
-      docker_image: brainles/brats24_isbi_algorithm1:latest
+      docker_image: brainles/brats24_isbi_goat_faking_it:latest
       input_name_schema: *input_name_schema
-      requires_root: "[ROOT_REQUIREMENT_1]"
+      requires_root: false
       parameters_file: false
 
 
   BraTS24_ISBI_2:
     meta:
-      authors: "[AUTHOR_NAME_2, et al.]"
+      authors: "[Anees Hashimi, et al.]"
       paper: "[PAPER_URL_2]"
-      challenge: *challenge
-      challenge_manuscript: *challenge_manuscript_2024
+      challenge: *isbi_challenge
+      challenge_manuscript: *isbi_challenge_manuscript_2024
       rank: *rank_2
       year: *year_2024
     run_args:
-      docker_image: brainles/brats24_isbi_algorithm2:latest
+      docker_image: brainles/brats24_isbi_goat_biomedia_mbzuai:latest
       input_name_schema: *input_name_schema
-      requires_root: "[ROOT_REQUIREMENT_2]"
+      requires_root: false
       parameters_file: false
 
-
-
-  BraTS24_ISBI_3:
-    meta:
-      authors: "[AUTHOR_NAME_3, et al.]"
-      paper: "[PAPER_URL_3]"
-      challenge: *challenge
-      challenge_manuscript: *challenge_manuscript_2024
-      rank: *rank_3
-      year: *year_2024
-    run_args:
-      docker_image: brainles/brats24_isbi_algorithm3:latest
-      input_name_schema: *input_name_schema
-      requires_root: "[ROOT_REQUIREMENT_3]"
-      parameters_file: false      

--- a/brats/data/meta/goat.yml
+++ b/brats/data/meta/goat.yml
@@ -8,7 +8,7 @@ constants:
     2024: &challenge_manuscript_2024 "N/A"
 
   isbi_challenge_manuscript:
-    2024: &isbi_challenge_manuscript_2024 "N/A"
+    2024: &isbi_challenge_manuscript_2024 "https://ieeexplore.ieee.org/document/10635839"
 
   years:
     2025: &year_2025 2025
@@ -95,7 +95,7 @@ algorithms:
   BraTS24_ISBI_1:
     meta:
       authors: "[André Ferreira, et al.]"
-      paper: "[PAPER_URL_1]"
+      paper: "https://arxiv.org/abs/2402.17317"
       challenge: *isbi_challenge
       challenge_manuscript: *isbi_challenge_manuscript_2024
       rank: *rank_1
@@ -109,7 +109,7 @@ algorithms:
 
   BraTS24_ISBI_2:
     meta:
-      authors: "[Anees Hashimi, et al.]"
+      authors: "[Anees Hashmi, et al.]"
       paper: "[PAPER_URL_2]"
       challenge: *isbi_challenge
       challenge_manuscript: *isbi_challenge_manuscript_2024
@@ -119,5 +119,8 @@ algorithms:
       docker_image: brainles/brats24_isbi_goat_biomedia_mbzuai:latest
       input_name_schema: *input_name_schema
       requires_root: false
-      parameters_file: false
+      parameters_file: true
+    additional_files:
+      record_id: "00000000"
+      param_name: ["checkpoint_dir"]  
 


### PR DESCRIPTION
This feature implements the top-2 algorithms from the IEEE-ISBI BraTS GoAT challenge from the year 2024. The images have already been pushed to the brainles docker hub page. The algorithm from the first place is executable, while for the second place, we are currently missing the correct Zenodo ID to download weights etc. 