### PR TITLE
ci: re-add Python 3.14 to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Python 3.14 was previously deferred in 57c849c because **flake8/pyflakes** was not yet 3.14-compatible.

The project has since migrated from flake8 to **ruff** (which is a native Rust binary and doesn't depend on Python version support for linting). This removes the original blocker.

Local testing with Python 3.14 confirms:
- All dependencies resolve successfully
- All tests pass

Ci for 3.14 will be faster once #161 is merged