### PR TITLE
fix: restore Python version badge metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,16 @@ keywords = [
   "synthesis",
   "inpainting",
 ]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+]
 
 dependencies = [
   "spython>=0.3.14",
@@ -53,10 +63,12 @@ preprocessing = ["brainles_preprocessing>=0.6.7; python_version >= '3.10'"]
 
 [dependency-groups]
 dev = [
+  "packaging>=24.0",
   "pytest>=8.0.0",
   "pytest-cov>=5.0.0",
   "ruff>=0.16.2",
   "pre-commit>=3.8.0",
+  "tomli>=2.0; python_version < '3.11'",
 ]
 docs = [
   "mkdocs-material>=9.5",

--- a/tests/test_python_support_metadata.py
+++ b/tests/test_python_support_metadata.py
@@ -1,0 +1,47 @@
+import re
+import sys
+from pathlib import Path
+
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+
+PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+
+def _project_metadata() -> dict:
+    return tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))["project"]
+
+
+def _python_classifier_versions(classifiers: list[str]) -> set[Version]:
+    versions = set()
+    for classifier in classifiers:
+        match = re.fullmatch(
+            r"Programming Language :: Python :: (\d+\.\d+)", classifier
+        )
+        if match:
+            versions.add(Version(match.group(1)))
+    return versions
+
+
+def test_python_classifiers_match_requires_python() -> None:
+    project = _project_metadata()
+    requirement = SpecifierSet(project["requires-python"])
+    versions = _python_classifier_versions(project["classifiers"])
+
+    assert versions
+    assert all(version in requirement for version in versions)
+
+
+def test_running_python_version_has_a_classifier() -> None:
+    project = _project_metadata()
+    versions = _python_classifier_versions(project["classifiers"])
+    current_version = Version(f"{sys.version_info.major}.{sys.version_info.minor}")
+
+    assert current_version in SpecifierSet(project["requires-python"])
+    assert current_version in versions

--- a/uv.lock
+++ b/uv.lock
@@ -275,12 +275,14 @@ preprocessing = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "packaging" },
     { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pre-commit", version = "4.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 docs = [
     { name = "mkdocs-git-revision-date-localized-plugin", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -308,10 +310,12 @@ provides-extras = ["preprocessing"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "packaging", specifier = ">=24.0" },
     { name = "pre-commit", specifier = ">=3.8.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "ruff", specifier = ">=0.16.2" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
 ]
 docs = [
     { name = "mkdocs-git-revision-date-localized-plugin", specifier = ">=1.2" },


### PR DESCRIPTION
## Summary

- Add Python 3.9 through 3.14 classifiers to the package metadata.
- Keep the existing PyPI Python-version badge in the README and documentation.
- Add tests that validate classifiers against `requires-python` and the running CI interpreter.

## Why

The Hatchling-built release included `Requires-Python` but no Python classifiers, causing the PyPI `pyversions` badge to display `missing`. Explicit classifiers are standard PyPI metadata and improve package discoverability and tooling support. Manual declarations were chosen over a Hatch hook because a hook would still need a maintained supported-version list while adding build complexity.

## Validation

- `uv run pytest` (89 passed)
- `uv run ruff check pyproject.toml tests/test_python_support_metadata.py`
- `uv run ruff format --check tests/test_python_support_metadata.py`
- Built wheel metadata verified for Python 3.9 through 3.14 classifiers