### PR TITLE
fix: honor cuda_devices in Singularity backend and support multiple GPUs in Docker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,10 +51,10 @@ Backend selection uses a Strategy pattern via dictionary dispatch in `_get_backe
 - **Docker** (`brats/core/docker.py`): Default backend. For algorithms from 2024 and earlier, it uses the MLCube `/mlcube_io0` through `/mlcube_io3` mounts and runs `infer`. For 2025 and newer algorithms, it mounts `/input` and `/output` and uses the image's default command. Images are pulled from Docker Hub when needed.
 - **Singularity** (`brats/core/singularity.py`): HPC-friendly backend. Converts Docker images to a sandbox, uses `--bind` for volume mounts, `--nv` for GPU support, and a temporary `--overlay` for writable storage. It follows the same year-dependent MLCube/native container split as Docker.
 
-Both backends expose a `run_container()` function with the same caller signature.
-Docker requests the IDs in `cuda_devices`; Singularity's `--nv` exposes host GPUs
-and does not apply that value as a GPU restriction. Use
-`SINGULARITYENV_CUDA_VISIBLE_DEVICES` when GPU selection is required.
+Both backends expose a `run_container()` function with the same caller signature
+and both honor `cuda_devices`: Docker requests the given device IDs (split on
+commas), while Singularity sets `SINGULARITYENV_CUDA_VISIBLE_DEVICES` around the
+container run to restrict the GPUs exposed by `--nv`. IDs refer to host GPUs.
 
 ### Algorithm configuration (data-driven registry)
 

--- a/brats/core/docker.py
+++ b/brats/core/docker.py
@@ -18,6 +18,7 @@ from rich.table import Table
 
 from brats.constants import DUMMY_PARAMETERS, PACKAGE_CITATION, PARAMETERS_DIR
 from brats.utils.algorithm_config import AlgorithmData
+from brats.utils.cuda import normalize_cuda_devices
 from brats.utils.exceptions import (
     AlgorithmNotCPUCompatibleException,
     BraTSContainerException,
@@ -128,7 +129,7 @@ def _handle_device_requests(
     # request gpu with chosen devices
     return [
         docker.types.DeviceRequest(
-            device_ids=[device.strip() for device in cuda_devices.split(",")],
+            device_ids=normalize_cuda_devices(cuda_devices).split(","),
             capabilities=[["gpu"]],
         )
     ]

--- a/brats/core/docker.py
+++ b/brats/core/docker.py
@@ -127,7 +127,10 @@ def _handle_device_requests(
         return []
     # request gpu with chosen devices
     return [
-        docker.types.DeviceRequest(device_ids=[cuda_devices], capabilities=[["gpu"]])
+        docker.types.DeviceRequest(
+            device_ids=[device.strip() for device in cuda_devices.split(",")],
+            capabilities=[["gpu"]],
+        )
     ]
 
 

--- a/brats/core/singularity.py
+++ b/brats/core/singularity.py
@@ -284,9 +284,10 @@ def run_container(
     options = []
 
     enable_gpu = len(device_requests) > 0 and not force_cpu
+    devices = normalize_cuda_devices(cuda_devices) if enable_gpu else cuda_devices
     if enable_gpu:
         logger.info(
-            f"Restricting container GPUs to CUDA devices: {cuda_devices} "
+            f"Restricting container GPUs to CUDA devices: {devices} "
             f"(via {_SINGULARITY_CUDA_ENV_VAR})"
         )
         options.append("--nv")  # Singularity uses --nv to enable GPU support
@@ -320,7 +321,7 @@ def run_container(
         )
         overlay_created = True
     try:
-        with _cuda_device_selection_env(cuda_devices=cuda_devices, enabled=enable_gpu):
+        with _cuda_device_selection_env(cuda_devices=devices, enabled=enable_gpu):
             executor = Client.run(
                 image,
                 options=options,

--- a/brats/core/singularity.py
+++ b/brats/core/singularity.py
@@ -27,6 +27,7 @@ from brats.core.docker import (
     _sanity_check_output,
 )
 from brats.utils.algorithm_config import AlgorithmData
+from brats.utils.cuda import normalize_cuda_devices
 
 try:
     docker_client = docker.from_env()
@@ -177,6 +178,12 @@ def _cuda_device_selection_env(cuda_devices: str, enabled: bool) -> Iterator[Non
             visible inside the container.
         enabled (bool): Whether to restrict GPUs at all. If ``False`` (CPU
             run), the environment is left untouched.
+
+    Note:
+        The environment override is process-global and therefore not
+        thread-safe. Concurrent Singularity runs within the same process
+        may interfere with each other's GPU selection; run containers
+        sequentially.
     """
     if not enabled:
         yield
@@ -195,7 +202,7 @@ def _cuda_device_selection_env(cuda_devices: str, enabled: bool) -> Iterator[Non
             f"(e.g. by a batch scheduler). The cuda_devices parameter refers "
             f"to host GPU IDs and takes precedence inside the container."
         )
-    os.environ[_SINGULARITY_CUDA_ENV_VAR] = cuda_devices
+    os.environ[_SINGULARITY_CUDA_ENV_VAR] = normalize_cuda_devices(cuda_devices)
     try:
         yield
     finally:

--- a/brats/core/singularity.py
+++ b/brats/core/singularity.py
@@ -4,6 +4,8 @@ import os
 import subprocess
 import tempfile
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Optional
 
@@ -156,6 +158,53 @@ def _get_docker_working_dir(image: str) -> Optional[Path]:
         return Path(workdir)
 
 
+_SINGULARITY_CUDA_ENV_VAR = "SINGULARITYENV_CUDA_VISIBLE_DEVICES"
+_HOST_CUDA_ENV_VAR = "CUDA_VISIBLE_DEVICES"
+
+
+@contextmanager
+def _cuda_device_selection_env(cuda_devices: str, enabled: bool) -> Iterator[None]:
+    """Temporarily expose only the requested GPUs inside the container.
+
+    Singularity's ``--nv`` flag exposes all host GPUs, so GPU selection is
+    enforced via the ``SINGULARITYENV_CUDA_VISIBLE_DEVICES`` environment
+    variable, which Singularity passes into the container as
+    ``CUDA_VISIBLE_DEVICES``. The previous value of the variable (if any) is
+    restored on exit.
+
+    Args:
+        cuda_devices (str): Comma-separated list of host GPU IDs to make
+            visible inside the container.
+        enabled (bool): Whether to restrict GPUs at all. If ``False`` (CPU
+            run), the environment is left untouched.
+    """
+    if not enabled:
+        yield
+        return
+
+    previous_value = os.environ.get(_SINGULARITY_CUDA_ENV_VAR)
+    if previous_value is not None:
+        logger.warning(
+            f"The {_SINGULARITY_CUDA_ENV_VAR} environment variable is already "
+            f"set to '{previous_value}'. It will be overridden with the "
+            f"cuda_devices parameter value '{cuda_devices}'."
+        )
+    if os.environ.get(_HOST_CUDA_ENV_VAR) is not None:
+        logger.warning(
+            f"The host's {_HOST_CUDA_ENV_VAR} environment variable is set "
+            f"(e.g. by a batch scheduler). The cuda_devices parameter refers "
+            f"to host GPU IDs and takes precedence inside the container."
+        )
+    os.environ[_SINGULARITY_CUDA_ENV_VAR] = cuda_devices
+    try:
+        yield
+    finally:
+        if previous_value is None:
+            os.environ.pop(_SINGULARITY_CUDA_ENV_VAR, None)
+        else:
+            os.environ[_SINGULARITY_CUDA_ENV_VAR] = previous_value
+
+
 def run_container(
     algorithm: AlgorithmData,
     data_path: Path,
@@ -227,8 +276,12 @@ def run_container(
 
     options = []
 
-    if len(device_requests) > 0 and not force_cpu:
-        logger.info(f"Using CUDA devices: {cuda_devices}")
+    enable_gpu = len(device_requests) > 0 and not force_cpu
+    if enable_gpu:
+        logger.info(
+            f"Restricting container GPUs to CUDA devices: {cuda_devices} "
+            f"(via {_SINGULARITY_CUDA_ENV_VAR})"
+        )
         options.append("--nv")  # Singularity uses --nv to enable GPU support
 
     # TODO: The --fakeroot option may be required for certain algorithms that
@@ -260,14 +313,15 @@ def run_container(
         )
         overlay_created = True
     try:
-        executor = Client.run(
-            image,
-            options=options,
-            args=args,
-            stream=True,
-            bind=singularity_bindings,
-        )
-        container_output = list(executor)
+        with _cuda_device_selection_env(cuda_devices=cuda_devices, enabled=enable_gpu):
+            executor = Client.run(
+                image,
+                options=options,
+                args=args,
+                stream=True,
+                bind=singularity_bindings,
+            )
+            container_output = list(executor)
 
         _sanity_check_output(
             data_path=data_path,

--- a/brats/utils/cuda.py
+++ b/brats/utils/cuda.py
@@ -1,0 +1,23 @@
+def normalize_cuda_devices(cuda_devices: str) -> str:
+    """Normalize a comma-separated list of CUDA device IDs.
+
+    Splits the input on commas, strips surrounding whitespace from each
+    entry, and drops empty entries, so that e.g. ``" 0 , 1 ,"`` becomes
+    ``"0,1"``.
+
+    Args:
+        cuda_devices (str): Comma-separated list of CUDA device IDs.
+
+    Returns:
+        str: Canonical comma-separated list of device IDs.
+
+    Raises:
+        ValueError: If the input contains no valid device IDs.
+    """
+    device_ids = [device for device in cuda_devices.split(",") if device.strip()]
+    if not device_ids:
+        raise ValueError(
+            f"No valid CUDA device IDs in cuda_devices='{cuda_devices}'. "
+            f"Expected a comma-separated list of device IDs, e.g. '0' or '0,1'."
+        )
+    return ",".join(device.strip() for device in device_ids)

--- a/docs/guides/backends.md
+++ b/docs/guides/backends.md
@@ -60,6 +60,7 @@ Notes:
 
 - `cuda_devices` refers to **host** GPU IDs. If the host already defines `CUDA_VISIBLE_DEVICES` (e.g., set by a batch scheduler such as SLURM), the `cuda_devices` value takes precedence inside the container.
 - Manually setting `SINGULARITYENV_CUDA_VISIBLE_DEVICES` is no longer necessary; the `cuda_devices` parameter overrides it.
+- The environment override is process-global and not thread-safe: run Singularity containers sequentially within a single process.
 
 ---
 

--- a/docs/guides/backends.md
+++ b/docs/guides/backends.md
@@ -29,6 +29,8 @@ Most algorithms require GPU acceleration. Ensure the [NVIDIA Container Toolkit](
 segmenter = AdultGliomaPreAndPostTreatmentSegmenter(cuda_devices="0")
 ```
 
+Multiple GPUs can be selected with a comma-separated string, e.g. `cuda_devices="0,1"`.
+
 ## Singularity
 
 [Singularity](https://docs.sylabs.io/guides/3.0/user-guide/installation.html) is fully supported for environments where Docker isn't available (e.g., HPC clusters).
@@ -48,13 +50,16 @@ segmenter.infer_single(
 
 ### GPU Acceleration
 
-Singularity uses the `--nv` flag to expose host GPUs — no additional toolkit is needed. However, `cuda_devices` is ignored; `--nv` [exposes all host GPUs](https://docs.sylabs.io/guides/latest/user-guide/gpu.html#multiple-gpus). To limit GPUs:
+Singularity uses the `--nv` flag to expose host GPUs — no additional toolkit is needed. The `cuda_devices` parameter is honored: the orchestrator sets `SINGULARITYENV_CUDA_VISIBLE_DEVICES` around the container run, so only the requested GPUs are visible inside it:
 
-```bash
-export SINGULARITYENV_CUDA_VISIBLE_DEVICES=0
+```python
+segmenter = AdultGliomaPreAndPostTreatmentSegmenter(cuda_devices="0,1")
 ```
 
-See [issue #164](https://github.com/BrainLesion/BraTS/issues/164).
+Notes:
+
+- `cuda_devices` refers to **host** GPU IDs. If the host already defines `CUDA_VISIBLE_DEVICES` (e.g., set by a batch scheduler such as SLURM), the `cuda_devices` value takes precedence inside the container.
+- Manually setting `SINGULARITYENV_CUDA_VISIBLE_DEVICES` is no longer necessary; the `cuda_devices` parameter overrides it.
 
 ---
 

--- a/tests/core/test_docker.py
+++ b/tests/core/test_docker.py
@@ -183,6 +183,21 @@ class TestDockerHelpers(unittest.TestCase):
         )
         self.assertEqual(result[0].device_ids, ["0", "1"])
 
+        # empty entries (e.g. trailing commas) are dropped
+        result = _handle_device_requests(
+            algorithm=self.algorithm_gpu, cuda_devices="0,1,", force_cpu=False
+        )
+        self.assertEqual(result[0].device_ids, ["0", "1"])
+
+    @patch("brats.core.docker._is_cuda_available", return_value=True)
+    def test_handle_device_requests_cuda_invalid_input_raises(
+        self, MockIsCudaAvailable
+    ):
+        with self.assertRaises(ValueError):
+            _handle_device_requests(
+                algorithm=self.algorithm_gpu, cuda_devices=" , ", force_cpu=False
+            )
+
     @patch("brats.core.docker._is_cuda_available", return_value=False)
     def test_handle_device_requests_force_cpu_valid(self, MockIsCudaAvailable):
         device_requests = _handle_device_requests(

--- a/tests/core/test_docker.py
+++ b/tests/core/test_docker.py
@@ -170,6 +170,19 @@ class TestDockerHelpers(unittest.TestCase):
         self.assertEqual(result[0].device_ids, ["42"])
         self.assertEqual(result[0].capabilities, [["gpu"]])
 
+    @patch("brats.core.docker._is_cuda_available", return_value=True)
+    def test_handle_device_requests_cuda_multiple_devices(self, MockIsCudaAvailable):
+        result = _handle_device_requests(
+            algorithm=self.algorithm_gpu, cuda_devices="0,1", force_cpu=False
+        )
+        self.assertEqual(result[0].device_ids, ["0", "1"])
+
+        # whitespace around device ids is tolerated
+        result = _handle_device_requests(
+            algorithm=self.algorithm_gpu, cuda_devices=" 0 , 1 ", force_cpu=False
+        )
+        self.assertEqual(result[0].device_ids, ["0", "1"])
+
     @patch("brats.core.docker._is_cuda_available", return_value=False)
     def test_handle_device_requests_force_cpu_valid(self, MockIsCudaAvailable):
         device_requests = _handle_device_requests(

--- a/tests/core/test_singularity.py
+++ b/tests/core/test_singularity.py
@@ -344,8 +344,9 @@ class TestSingularityHelpers(unittest.TestCase):
 
         mock_client.run.side_effect = capture_env
 
-        os.environ["SINGULARITYENV_CUDA_VISIBLE_DEVICES"] = "3"
-        try:
+        with patch.dict(os.environ):
+            os.environ["SINGULARITYENV_CUDA_VISIBLE_DEVICES"] = "3"
+
             run_container(
                 algorithm=self.algorithm_gpu,
                 data_path=self.data_folder,
@@ -364,8 +365,6 @@ class TestSingularityHelpers(unittest.TestCase):
                 any("already set" in message for message in warnings),
                 f"Expected an 'already set' warning, got: {warnings}",
             )
-        finally:
-            os.environ.pop("SINGULARITYENV_CUDA_VISIBLE_DEVICES", None)
 
     @patch("brats.core.singularity.logger")
     @patch("brats.core.singularity._log_algorithm_info")

--- a/tests/core/test_singularity.py
+++ b/tests/core/test_singularity.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import tempfile
 import unittest
@@ -239,3 +240,178 @@ class TestSingularityHelpers(unittest.TestCase):
         mock_get_docker_working_dir.assert_called_once()
         mock_subprocess_run.assert_called_once()
         mock_client.run.assert_called_once()
+
+    @patch("brats.core.singularity.logger")
+    @patch("brats.core.singularity._log_algorithm_info")
+    @patch("brats.core.singularity._ensure_image")
+    @patch("brats.core.singularity._get_additional_files_path")
+    @patch("brats.core.singularity._get_volume_mappings_mlcube")
+    @patch("brats.core.singularity._build_command_args")
+    @patch("brats.core.singularity._handle_device_requests")
+    @patch("brats.core.singularity._convert_volume_mappings_to_singularity_format")
+    @patch("brats.core.singularity.Client")
+    @patch("brats.core.singularity.subprocess.run")
+    @patch("brats.core.singularity._get_docker_working_dir")
+    def test_run_container_sets_cuda_visible_devices(
+        self,
+        mock_get_docker_working_dir,
+        mock_subprocess_run,
+        mock_client,
+        mock_convert_volume_mappings_to_singularity_format,
+        mock_handle_device_requests,
+        mock_build_command_args,
+        mock_get_volume_mappings_mlcube,
+        mock_get_additional_files_path,
+        mock_ensure_image,
+        mock_log_algorithm_info,
+        mock_logger,
+    ):
+        mock_handle_device_requests.return_value = [MagicMock()]  # GPU requested
+        mock_build_command_args.return_value = ["--data_path=/mlcube_io0"]
+        mock_ensure_image.return_value = str(
+            self.test_dir / "brats_singularity_images" / "brainles_test-image_latest"
+        )
+
+        captured_env = {}
+
+        def capture_env(*args, **kwargs):
+            captured_env["value"] = os.environ.get(
+                "SINGULARITYENV_CUDA_VISIBLE_DEVICES"
+            )
+            return iter([])
+
+        mock_client.run.side_effect = capture_env
+
+        run_container(
+            algorithm=self.algorithm_gpu,
+            data_path=self.data_folder,
+            output_path=self.output_folder,
+            cuda_devices="0,1",
+            force_cpu=False,
+        )
+
+        # the container sees only the requested devices while running
+        self.assertEqual(captured_env["value"], "0,1")
+        options = mock_client.run.call_args.kwargs["options"]
+        self.assertIn("--nv", options)
+        # environment is restored after the run
+        self.assertNotIn("SINGULARITYENV_CUDA_VISIBLE_DEVICES", os.environ)
+
+    @patch("brats.core.singularity.logger")
+    @patch("brats.core.singularity._log_algorithm_info")
+    @patch("brats.core.singularity._ensure_image")
+    @patch("brats.core.singularity._get_additional_files_path")
+    @patch("brats.core.singularity._get_volume_mappings_mlcube")
+    @patch("brats.core.singularity._build_command_args")
+    @patch("brats.core.singularity._handle_device_requests")
+    @patch("brats.core.singularity._convert_volume_mappings_to_singularity_format")
+    @patch("brats.core.singularity.Client")
+    @patch("brats.core.singularity.subprocess.run")
+    @patch("brats.core.singularity._get_docker_working_dir")
+    def test_run_container_overrides_and_restores_existing_cuda_env(
+        self,
+        mock_get_docker_working_dir,
+        mock_subprocess_run,
+        mock_client,
+        mock_convert_volume_mappings_to_singularity_format,
+        mock_handle_device_requests,
+        mock_build_command_args,
+        mock_get_volume_mappings_mlcube,
+        mock_get_additional_files_path,
+        mock_ensure_image,
+        mock_log_algorithm_info,
+        mock_logger,
+    ):
+        mock_handle_device_requests.return_value = [MagicMock()]  # GPU requested
+        mock_build_command_args.return_value = ["--data_path=/mlcube_io0"]
+        mock_ensure_image.return_value = str(
+            self.test_dir / "brats_singularity_images" / "brainles_test-image_latest"
+        )
+        mock_client.run.return_value = iter([])
+
+        captured_env = {}
+
+        def capture_env(*args, **kwargs):
+            captured_env["value"] = os.environ.get(
+                "SINGULARITYENV_CUDA_VISIBLE_DEVICES"
+            )
+            return iter([])
+
+        mock_client.run.side_effect = capture_env
+
+        os.environ["SINGULARITYENV_CUDA_VISIBLE_DEVICES"] = "3"
+        try:
+            run_container(
+                algorithm=self.algorithm_gpu,
+                data_path=self.data_folder,
+                output_path=self.output_folder,
+                cuda_devices="0",
+                force_cpu=False,
+            )
+
+            # cuda_devices parameter takes precedence while running
+            self.assertEqual(captured_env["value"], "0")
+            # pre-existing value is restored afterwards
+            self.assertEqual(os.environ["SINGULARITYENV_CUDA_VISIBLE_DEVICES"], "3")
+            # overriding a user-provided value is flagged
+            warnings = [call.args[0] for call in mock_logger.warning.call_args_list]
+            self.assertTrue(
+                any("already set" in message for message in warnings),
+                f"Expected an 'already set' warning, got: {warnings}",
+            )
+        finally:
+            os.environ.pop("SINGULARITYENV_CUDA_VISIBLE_DEVICES", None)
+
+    @patch("brats.core.singularity.logger")
+    @patch("brats.core.singularity._log_algorithm_info")
+    @patch("brats.core.singularity._ensure_image")
+    @patch("brats.core.singularity._get_additional_files_path")
+    @patch("brats.core.singularity._get_volume_mappings_mlcube")
+    @patch("brats.core.singularity._build_command_args")
+    @patch("brats.core.singularity._handle_device_requests")
+    @patch("brats.core.singularity._convert_volume_mappings_to_singularity_format")
+    @patch("brats.core.singularity.Client")
+    @patch("brats.core.singularity.subprocess.run")
+    @patch("brats.core.singularity._get_docker_working_dir")
+    def test_run_container_cpu_does_not_touch_cuda_env(
+        self,
+        mock_get_docker_working_dir,
+        mock_subprocess_run,
+        mock_client,
+        mock_convert_volume_mappings_to_singularity_format,
+        mock_handle_device_requests,
+        mock_build_command_args,
+        mock_get_volume_mappings_mlcube,
+        mock_get_additional_files_path,
+        mock_ensure_image,
+        mock_log_algorithm_info,
+        mock_logger,
+    ):
+        mock_handle_device_requests.return_value = []  # CPU run
+        mock_build_command_args.return_value = ["--data_path=/mlcube_io0"]
+        mock_ensure_image.return_value = str(
+            self.test_dir / "brats_singularity_images" / "brainles_test-image_latest"
+        )
+
+        captured_env = {}
+
+        def capture_env(*args, **kwargs):
+            captured_env["value"] = os.environ.get(
+                "SINGULARITYENV_CUDA_VISIBLE_DEVICES"
+            )
+            return iter([])
+
+        mock_client.run.side_effect = capture_env
+
+        run_container(
+            algorithm=self.algorithm_gpu,
+            data_path=self.data_folder,
+            output_path=self.output_folder,
+            cuda_devices="0",
+            force_cpu=False,
+        )
+
+        self.assertIsNone(captured_env["value"])
+        options = mock_client.run.call_args.kwargs["options"]
+        self.assertNotIn("--nv", options)
+        self.assertNotIn("SINGULARITYENV_CUDA_VISIBLE_DEVICES", os.environ)

--- a/tests/core/test_singularity.py
+++ b/tests/core/test_singularity.py
@@ -282,20 +282,25 @@ class TestSingularityHelpers(unittest.TestCase):
 
         mock_client.run.side_effect = capture_env
 
-        run_container(
-            algorithm=self.algorithm_gpu,
-            data_path=self.data_folder,
-            output_path=self.output_folder,
-            cuda_devices="0,1",
-            force_cpu=False,
-        )
+        with patch.dict(os.environ):
+            # hermetic: ensure the variable is not set by the surrounding environment
+            os.environ.pop("SINGULARITYENV_CUDA_VISIBLE_DEVICES", None)
 
-        # the container sees only the requested devices while running
-        self.assertEqual(captured_env["value"], "0,1")
-        options = mock_client.run.call_args.kwargs["options"]
-        self.assertIn("--nv", options)
-        # environment is restored after the run
-        self.assertNotIn("SINGULARITYENV_CUDA_VISIBLE_DEVICES", os.environ)
+            run_container(
+                algorithm=self.algorithm_gpu,
+                data_path=self.data_folder,
+                output_path=self.output_folder,
+                cuda_devices=" 0 , 1 ",
+                force_cpu=False,
+            )
+
+            # the container sees only the requested devices while running;
+            # whitespace around ids is normalized away
+            self.assertEqual(captured_env["value"], "0,1")
+            options = mock_client.run.call_args.kwargs["options"]
+            self.assertIn("--nv", options)
+            # environment is restored after the run
+            self.assertNotIn("SINGULARITYENV_CUDA_VISIBLE_DEVICES", os.environ)
 
     @patch("brats.core.singularity.logger")
     @patch("brats.core.singularity._log_algorithm_info")
@@ -403,15 +408,21 @@ class TestSingularityHelpers(unittest.TestCase):
 
         mock_client.run.side_effect = capture_env
 
-        run_container(
-            algorithm=self.algorithm_gpu,
-            data_path=self.data_folder,
-            output_path=self.output_folder,
-            cuda_devices="0",
-            force_cpu=False,
-        )
+        with patch.dict(os.environ):
+            os.environ["SINGULARITYENV_CUDA_VISIBLE_DEVICES"] = "sentinel"
 
-        self.assertIsNone(captured_env["value"])
-        options = mock_client.run.call_args.kwargs["options"]
-        self.assertNotIn("--nv", options)
-        self.assertNotIn("SINGULARITYENV_CUDA_VISIBLE_DEVICES", os.environ)
+            run_container(
+                algorithm=self.algorithm_gpu,
+                data_path=self.data_folder,
+                output_path=self.output_folder,
+                cuda_devices="0",
+                force_cpu=False,
+            )
+
+            # the sentinel survives the run: the CPU path does not touch the env
+            self.assertEqual(captured_env["value"], "sentinel")
+            options = mock_client.run.call_args.kwargs["options"]
+            self.assertNotIn("--nv", options)
+            self.assertEqual(
+                os.environ["SINGULARITYENV_CUDA_VISIBLE_DEVICES"], "sentinel"
+            )

--- a/tests/utils/test_cuda.py
+++ b/tests/utils/test_cuda.py
@@ -1,0 +1,25 @@
+import unittest
+
+from brats.utils.cuda import normalize_cuda_devices
+
+
+class TestNormalizeCudaDevices(unittest.TestCase):
+    def test_single_device(self):
+        self.assertEqual(normalize_cuda_devices("0"), "0")
+
+    def test_multiple_devices(self):
+        self.assertEqual(normalize_cuda_devices("0,1,2"), "0,1,2")
+
+    def test_strips_whitespace_around_ids(self):
+        self.assertEqual(normalize_cuda_devices(" 0 , 1 "), "0,1")
+
+    def test_drops_empty_entries(self):
+        self.assertEqual(normalize_cuda_devices("0,,1,"), "0,1")
+
+    def test_whitespace_only_input_raises(self):
+        with self.assertRaises(ValueError):
+            normalize_cuda_devices(" , , ")
+
+    def test_empty_input_raises(self):
+        with self.assertRaises(ValueError):
+            normalize_cuda_devices("")


### PR DESCRIPTION
## Summary

Fixes #164.

- **Singularity**: `cuda_devices` was silently ignored — the `--nv` flag exposes *all* host GPUs. The Singularity backend now sets `SINGULARITYENV_CUDA_VISIBLE_DEVICES` around the container run (Singularity passes it into the container as `CUDA_VISIBLE_DEVICES`), so only the requested host GPUs are visible. Any previously set value is restored after the run, and a warning is logged if it was already set.
- **Docker**: `cuda_devices` now accepts a comma-separated list of device IDs (e.g. `"0,1"`); entries are split on commas and whitespace is stripped.
- Documented that `cuda_devices` refers to **host** GPU IDs and takes precedence over a host-level `CUDA_VISIBLE_DEVICES` (e.g. set by SLURM) inside the container; updated AGENTS.md and `docs/guides/backends.md` accordingly.

## Testing

- `uv run pytest` — 93 passed (tests mock container execution; no Docker daemon/GPU required)
- `uv run ruff check .` and `uv run ruff format --check .` — clean